### PR TITLE
refactor: ContentBuilder導入とmarkdownインラインマーカー共通化

### DIFF
--- a/lua/ghsigns/lualine.lua
+++ b/lua/ghsigns/lualine.lua
@@ -203,13 +203,12 @@ local function prepare_pr_data(pr)
   return p
 end
 
---- Build the header section (title, branches, metadata, dates)
+--- Add title line with optional DRAFT indicator
 ---@param self Ghsigns.ContentBuilder
 ---@param p Ghsigns.PrData
 ---@return integer title_line
 ---@return string title_text
-function ContentBuilder:build_header(p)
-  -- Title with Draft indicator
+function ContentBuilder:add_title_line(p)
   local title_prefix = (p.isDraft == true) and "[DRAFT] " or ""
   local title_text = "#" .. (p.number or 0) .. " " .. title_prefix .. (p.title or "")
   local number_str = tostring(p.number or 0)
@@ -224,49 +223,13 @@ function ContentBuilder:build_header(p)
     table.insert(title_hls, { col = #number_str + 2, end_col = -1, hl = "GhsignsPrTitle" })
   end
   self:add_line(title_text, title_hls)
-  local title_line = #self.lines - 1
+  return #self.lines - 1, title_text
+end
 
-  -- Branches
-  if p.baseRefName and p.headRefName then
-    local branch_info = string.format("%s ← %s", p.baseRefName, p.headRefName)
-    self:add_line(branch_info, {
-      { col = 0, end_col = #p.baseRefName, hl = "String" },
-      { col = #p.baseRefName + 1, end_col = #p.baseRefName + 3, hl = "Operator" },
-      { col = #p.baseRefName + 4, end_col = -1, hl = "Identifier" },
-    })
-  end
-
-  self:add_line ""
-
-  -- Author
-  if p.author_name then
-    self:add_labeled("Author", p.author_name, "String")
-  end
-
-  -- State
-  if p.state then
-    local state_hl = p.state == "OPEN" and "DiagnosticOk" or "DiagnosticError"
-    self:add_labeled("State", p.state, state_hl)
-  end
-
-  -- Review Decision
-  if p.reviewDecision and p.reviewDecision ~= "" then
-    local review_hl = "DiagnosticWarn"
-    if p.reviewDecision == "APPROVED" then
-      review_hl = "DiagnosticOk"
-    elseif p.reviewDecision == "CHANGES_REQUESTED" then
-      review_hl = "DiagnosticError"
-    end
-    self:add_labeled("Review", p.reviewDecision:gsub("_", " "), review_hl)
-  end
-
-  -- Mergeable
-  if p.mergeable and p.mergeable ~= "" then
-    local merge_hl = p.mergeable == "MERGEABLE" and "DiagnosticOk" or "DiagnosticError"
-    self:add_labeled("Mergeable", p.mergeable, merge_hl)
-  end
-
-  -- Changes
+--- Add changes line with diff-colored highlights
+---@param self Ghsigns.ContentBuilder
+---@param p Ghsigns.PrData
+function ContentBuilder:add_changes_line(p)
   local commit_count = 0
   if p.commits then
     if p.commits.nodes then
@@ -293,18 +256,50 @@ function ContentBuilder:build_header(p)
     { col = minus_start, end_col = minus_end, hl = "DiffDelete" },
     { col = minus_end + 1, end_col = -1, hl = "Comment" },
   })
+end
 
-  -- Labels
+--- Add metadata fields (Author, State, Review, Mergeable, Changes, Labels)
+---@param self Ghsigns.ContentBuilder
+---@param p Ghsigns.PrData
+function ContentBuilder:add_metadata_fields(p)
+  if p.author_name then
+    self:add_labeled("Author", p.author_name, "String")
+  end
+
+  if p.state then
+    local state_hl = p.state == "OPEN" and "DiagnosticOk" or "DiagnosticError"
+    self:add_labeled("State", p.state, state_hl)
+  end
+
+  if p.reviewDecision and p.reviewDecision ~= "" then
+    local review_hl = "DiagnosticWarn"
+    if p.reviewDecision == "APPROVED" then
+      review_hl = "DiagnosticOk"
+    elseif p.reviewDecision == "CHANGES_REQUESTED" then
+      review_hl = "DiagnosticError"
+    end
+    self:add_labeled("Review", p.reviewDecision:gsub("_", " "), review_hl)
+  end
+
+  if p.mergeable and p.mergeable ~= "" then
+    local merge_hl = p.mergeable == "MERGEABLE" and "DiagnosticOk" or "DiagnosticError"
+    self:add_labeled("Mergeable", p.mergeable, merge_hl)
+  end
+
+  self:add_changes_line(p)
+
   if p.labels and p.labels.nodes and #p.labels.nodes > 0 then
     local label_names = vim.tbl_map(function(label)
       return label.name
     end, p.labels.nodes)
     self:add_labeled("Labels", table.concat(label_names, ", "), "Tag")
   end
+end
 
-  self:add_line ""
-
-  -- Dates
+--- Add date fields (Created, Updated, Merged)
+---@param self Ghsigns.ContentBuilder
+---@param p Ghsigns.PrData
+function ContentBuilder:add_date_fields(p)
   if p.createdAt then
     self:add_labeled("Created", p.createdAt, "DiagnosticHint")
   end
@@ -314,6 +309,29 @@ function ContentBuilder:build_header(p)
   if p.mergedAt then
     self:add_labeled("Merged", p.mergedAt, "DiagnosticOk")
   end
+end
+
+--- Build the header section (title, branches, metadata, dates)
+---@param self Ghsigns.ContentBuilder
+---@param p Ghsigns.PrData
+---@return integer title_line
+---@return string title_text
+function ContentBuilder:build_header(p)
+  local title_line, title_text = self:add_title_line(p)
+
+  if p.baseRefName and p.headRefName then
+    local branch_info = string.format("%s ← %s", p.baseRefName, p.headRefName)
+    self:add_line(branch_info, {
+      { col = 0, end_col = #p.baseRefName, hl = "String" },
+      { col = #p.baseRefName + 1, end_col = #p.baseRefName + 3, hl = "Operator" },
+      { col = #p.baseRefName + 4, end_col = -1, hl = "Identifier" },
+    })
+  end
+
+  self:add_line ""
+  self:add_metadata_fields(p)
+  self:add_line ""
+  self:add_date_fields(p)
 
   return title_line, title_text
 end
@@ -581,6 +599,27 @@ local function wrap_line(text, max_width, indent)
   return lines_out
 end
 
+--- Normalize body text: fix line endings, strip HTML, compress blank lines
+---@param body string
+---@return string[]
+local function normalize_body(body)
+  local text = body:gsub("\r\n", "\n"):gsub("\r", "\n")
+  text = text:gsub("<!%-%-.-%-%->", "")
+  text = text:gsub("<[^>]+>", "")
+
+  local raw_lines = vim.split(text, "\n")
+  local cleaned = {}
+  local prev_blank = false
+  for _, line in ipairs(raw_lines) do
+    local is_blank = line:match "^%s*$" ~= nil
+    if not (is_blank and prev_blank) then
+      table.insert(cleaned, line)
+    end
+    prev_blank = is_blank
+  end
+  return cleaned
+end
+
 --- Build the body section (description with markdown rendering)
 ---@param self Ghsigns.ContentBuilder
 ---@param p Ghsigns.PrData
@@ -589,7 +628,6 @@ function ContentBuilder:build_body(p)
     return
   end
 
-  -- Extract base repository URL from PR URL
   local repo_base_url = nil
   if p.url then
     repo_base_url = p.url:match "(https://[^/]+/[^/]+/[^/]+)"
@@ -598,28 +636,7 @@ function ContentBuilder:build_body(p)
   self:add_line ""
   self:add_line("Description:", { { col = 0, end_col = -1, hl = "Comment" } })
 
-  -- Normalize line endings (remove CR)
-  local normalized_body = p.body:gsub("\r\n", "\n"):gsub("\r", "\n")
-
-  -- Remove HTML comments
-  normalized_body = normalized_body:gsub("<!%-%-.-%-%->", "")
-
-  -- Remove HTML tags
-  normalized_body = normalized_body:gsub("<[^>]+>", "")
-
-  local body_lines = vim.split(normalized_body, "\n")
-
-  -- Remove consecutive blank lines
-  local cleaned_lines = {}
-  local prev_blank = false
-  for _, line in ipairs(body_lines) do
-    local is_blank = line:match "^%s*$" ~= nil
-    if not (is_blank and prev_blank) then
-      table.insert(cleaned_lines, line)
-    end
-    prev_blank = is_blank
-  end
-
+  local cleaned_lines = normalize_body(p.body)
   local in_code_block = false
   local lines_shown = 0
   local max_lines = 15
@@ -628,7 +645,6 @@ function ContentBuilder:build_body(p)
   for _, body_line in ipairs(cleaned_lines) do
     local lines_before = #self.lines
 
-    -- Code blocks ```
     if body_line:match "^```" then
       in_code_block = not in_code_block
       self:add_line("  " .. body_line, { { col = 0, end_col = -1, hl = "Comment" } })

--- a/lua/ghsigns/markdown.lua
+++ b/lua/ghsigns/markdown.lua
@@ -115,6 +115,88 @@ local function process_code_markers(text, hl_group, highlights, links)
   return processed
 end
 
+--- Process [text](url) links: remove markers and produce highlight/link entries
+---@param text string
+---@param highlights Ghsigns.Markdown.Highlight[]
+---@param links Ghsigns.Markdown.Link[]
+---@return string processed
+local function process_links(text, highlights, links)
+  local processed = ""
+  local i = 1
+  while i <= #text do
+    local s, e = text:find("%[([^%]]+)%]%([^%)]+%)", i)
+    if s == i then
+      local link_text = text:match("%[([^%]]+)%]%([^%)]+%)", i)
+      local url = text:match("%[[^%]]+%]%(([^%)]+)%)", i)
+      local start_col = #processed
+      processed = processed .. link_text
+      table.insert(highlights, { col = start_col, end_col = start_col + #link_text, hl = "Underlined" })
+      table.insert(links, { col_start = start_col, col_end = start_col + #link_text, url = url })
+      i = e + 1
+    else
+      processed = processed .. text:sub(i, i)
+      i = i + 1
+    end
+  end
+  return processed
+end
+
+--- Process #123 issue/PR references: make them clickable (skip inside backticks)
+---@param text string
+---@param repo_base_url string
+---@param highlights Ghsigns.Markdown.Highlight[]
+---@param links Ghsigns.Markdown.Link[]
+---@return string processed
+local function process_issue_refs(text, repo_base_url, highlights, links)
+  local processed = ""
+  local i = 1
+  local in_backtick = false
+  while i <= #text do
+    if text:sub(i, i) == "`" then
+      in_backtick = not in_backtick
+      processed = processed .. "`"
+      i = i + 1
+    else
+      local s, e = text:find("#%d+", i)
+      if s == i and not in_backtick then
+        local issue_num = text:match("#(%d+)", i)
+        local issue_text = "#" .. issue_num
+        local url = repo_base_url .. "/issues/" .. issue_num
+        local start_col = #processed
+        processed = processed .. issue_text
+        table.insert(highlights, { col = start_col, end_col = start_col + #issue_text, hl = "Underlined" })
+        table.insert(links, { col_start = start_col, col_end = start_col + #issue_text, url = url })
+        i = e + 1
+      else
+        processed = processed .. text:sub(i, i)
+        i = i + 1
+      end
+    end
+  end
+  return processed
+end
+
+--- Prepend blockquote visual prefix and shift all highlight/link positions
+---@param text string
+---@param quote_prefix string
+---@param highlights Ghsigns.Markdown.Highlight[]
+---@param links Ghsigns.Markdown.Link[]
+---@return string
+local function apply_blockquote_prefix(text, quote_prefix, highlights, links)
+  local offset = #quote_prefix
+  text = quote_prefix .. text
+  table.insert(highlights, 1, { col = 0, end_col = offset, hl = "FloatBorder" })
+  for idx = 2, #highlights do
+    highlights[idx].col = highlights[idx].col + offset
+    highlights[idx].end_col = highlights[idx].end_col + offset
+  end
+  for _, link in ipairs(links) do
+    link.col_start = link.col_start + offset
+    link.col_end = link.col_end + offset
+  end
+  return text
+end
+
 --- Render markdown text to plain text with highlight and link metadata
 ---@param text string The markdown text to render
 ---@param repo_base_url? string Optional repository base URL for issue/PR references
@@ -123,14 +205,11 @@ end
 ---@return Ghsigns.Markdown.Link[] links
 ---@return string? special_type Special type like "heading" if applicable
 Markdown.render = function(text, repo_base_url)
-  local rendered_text = text
+  local rendered_text = text:gsub("\r", "")
   local highlights = {}
   local links = {}
 
-  -- Remove CR characters
-  rendered_text = rendered_text:gsub("\r", "")
-
-  -- Heading (# ## ###) - remove prefix
+  -- Heading (# ## ###) - early return
   local heading_content = rendered_text:match "^#+%s+(.+)$"
   if heading_content then
     rendered_text = heading_content
@@ -138,7 +217,7 @@ Markdown.render = function(text, repo_base_url)
     return rendered_text, highlights, links, "heading"
   end
 
-  -- Blockquote (> ) - replace prefix with visual bar
+  -- Blockquote (> ) - extract prefix
   local quote_prefix = ""
   local is_blockquote = false
   while rendered_text:match "^>%s?" do
@@ -147,100 +226,27 @@ Markdown.render = function(text, repo_base_url)
     is_blockquote = true
   end
 
-  -- List items (- * 1.) - keep the marker
-  local list_marker, list_content = rendered_text:match "^(%s*[-*]%s)(.*)$"
-  if not list_marker then
-    list_marker, list_content = rendered_text:match "^(%s*%d+%.%s)(.*)$"
-  end
+  -- List items (- * 1.) - detect marker
+  local list_marker = rendered_text:match "^(%s*[-*]%s)"
+    or rendered_text:match "^(%s*%d+%.%s)"
 
-  -- Process inline markdown elements
-  local processed = ""
-
-  -- Links [text](url) - show only text, make it clickable (process first to avoid conflicts)
-  local i = 1
-  while i <= #rendered_text do
-    local s, e = rendered_text:find("%[([^%]]+)%]%([^%)]+%)", i)
-    if s == i then
-      local link_text = rendered_text:match("%[([^%]]+)%]%([^%)]+%)", i)
-      local url = rendered_text:match("%[[^%]]+%]%(([^%)]+)%)", i)
-      local start_col = #processed
-      processed = processed .. link_text
-      table.insert(highlights, { col = start_col, end_col = start_col + #link_text, hl = "Underlined" })
-      table.insert(links, {
-        col_start = start_col,
-        col_end = start_col + #link_text,
-        url = url,
-      })
-      i = e + 1
-    else
-      processed = processed .. rendered_text:sub(i, i)
-      i = i + 1
-    end
-  end
-  rendered_text = processed
-
-  -- Issue/PR references #123 - make them clickable (but not inside backticks)
+  -- Process inline elements
+  rendered_text = process_links(rendered_text, highlights, links)
   if repo_base_url then
-    processed = ""
-    i = 1
-    local in_backtick = false
-    while i <= #rendered_text do
-      -- Track backticks to avoid processing #123 inside code
-      if rendered_text:sub(i, i) == "`" then
-        in_backtick = not in_backtick
-        processed = processed .. "`"
-        i = i + 1
-      else
-        local s, e = rendered_text:find("#%d+", i)
-        if s == i and not in_backtick then
-          local issue_num = rendered_text:match("#(%d+)", i)
-          local issue_text = "#" .. issue_num
-          local url = repo_base_url .. "/issues/" .. issue_num
-          local start_col = #processed
-          processed = processed .. issue_text
-          table.insert(highlights, { col = start_col, end_col = start_col + #issue_text, hl = "Underlined" })
-          table.insert(links, {
-            col_start = start_col,
-            col_end = start_col + #issue_text,
-            url = url,
-          })
-          i = e + 1
-        else
-          processed = processed .. rendered_text:sub(i, i)
-          i = i + 1
-        end
-      end
-    end
-    rendered_text = processed
+    rendered_text = process_issue_refs(rendered_text, repo_base_url, highlights, links)
   end
-
-  -- Bold **text** - remove markers
   rendered_text = process_paired_markers(rendered_text, "%*%*([^*]+)%*%*", "Bold", 2, highlights, links)
-
-  -- Strikethrough ~~text~~ - remove markers
   rendered_text = process_paired_markers(rendered_text, "~~([^~]+)~~", "DiagnosticDeprecated", 2, highlights, links)
-
-  -- Code `text` - remove backticks
   rendered_text = process_code_markers(rendered_text, "String", highlights, links)
 
-  -- Add list marker highlight if present
+  -- Add list marker highlight
   if list_marker then
     table.insert(highlights, 1, { col = 0, end_col = #list_marker, hl = "Special" })
   end
 
-  -- Prepend blockquote prefix and shift all positions
+  -- Prepend blockquote prefix
   if is_blockquote then
-    local offset = #quote_prefix
-    rendered_text = quote_prefix .. rendered_text
-    table.insert(highlights, 1, { col = 0, end_col = offset, hl = "FloatBorder" })
-    for idx = 2, #highlights do
-      highlights[idx].col = highlights[idx].col + offset
-      highlights[idx].end_col = highlights[idx].end_col + offset
-    end
-    for _, link in ipairs(links) do
-      link.col_start = link.col_start + offset
-      link.col_end = link.col_end + offset
-    end
+    rendered_text = apply_blockquote_prefix(rendered_text, quote_prefix, highlights, links)
     return rendered_text, highlights, links, "blockquote"
   end
 


### PR DESCRIPTION
## Summary

- `markdown.lua`: Bold/Strikethrough/Code の3重複パターンを `process_paired_markers` / `process_code_markers` に統合
- `lualine.lua`: `show_pr_info` を `apply_content_to_buffer` / `open_float_window` / `setup_float_keymaps` に分割
- `lualine.lua`: クロージャ依存の `build_pr_content` を `ContentBuilder` クラスに置換し、`build_header` / `build_body` / `build_footer` に分解
- `lualine.lua`: `add_markdown_line` を `wrap_words` / `distribute_highlights` / `distribute_links` の純粋関数と `add_wrapped_markdown` / `add_simple_markdown` に分解

## Test plan

- [x] 全45テスト（うちレンダリング45件）が各コミットで通ることを確認済み
- [ ] Neovim上でlualineコンポーネントのPR情報フロートが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)