### PR TITLE
fix: prevent duplicate link opening in OSC 8 terminals

### DIFF
--- a/lua/ghsigns/pr_display.lua
+++ b/lua/ghsigns/pr_display.lua
@@ -5,6 +5,49 @@ local prepare_pr_data = cb.prepare_pr_data
 
 local float_win = FloatWin.new()
 
+local _osc8_supported = nil
+
+--- Check if the terminal supports OSC 8 hyperlinks
+---@return boolean
+local function supports_osc8()
+  if _osc8_supported ~= nil then
+    return _osc8_supported
+  end
+
+  local term = vim.env.TERM_PROGRAM
+  if term then
+    local osc8_terminals = {
+      ["iTerm.app"] = true,
+      ["WezTerm"] = true,
+      ["kitty"] = true,
+      ["foot"] = true,
+      ["contour"] = true,
+      ["rio"] = true,
+      ["alacritty"] = true,
+      ["ghostty"] = true,
+    }
+    if osc8_terminals[term] then
+      _osc8_supported = true
+      return true
+    end
+  end
+
+  -- VTE-based terminals (GNOME Terminal, etc.)
+  if vim.env.VTE_VERSION then
+    _osc8_supported = true
+    return true
+  end
+
+  -- Windows Terminal
+  if vim.env.WT_SESSION then
+    _osc8_supported = true
+    return true
+  end
+
+  _osc8_supported = false
+  return false
+end
+
 local PrDisplay = {}
 
 --- Build PR content for display (extracted for testability)
@@ -130,18 +173,22 @@ local function setup_float_keymaps(buf, ns, win, content)
         return
       end
 
-      local click_line = mouse.line - 1
-      local click_col = mouse.column - 1
-      local extmarks =
-        vim.api.nvim_buf_get_extmarks(buf, ns, { click_line, 0 }, { click_line + 1, 0 }, { details = true })
-      for _, mark in ipairs(extmarks) do
-        local _, _, start_col, details = unpack(mark)
-        if details.url then
-          local end_col = details.end_col or (start_col + 1)
-          if click_col >= start_col and click_col < end_col then
-            vim.notify("Opening: " .. details.url, vim.log.levels.INFO)
-            vim.ui.open(details.url)
-            return
+      -- In OSC 8 terminals, the terminal handles link clicks natively.
+      -- Only use Neovim-level link handling as a fallback for non-OSC 8 terminals.
+      if not supports_osc8() then
+        local click_line = mouse.line - 1
+        local click_col = mouse.column - 1
+        local extmarks =
+          vim.api.nvim_buf_get_extmarks(buf, ns, { click_line, 0 }, { click_line + 1, 0 }, { details = true })
+        for _, mark in ipairs(extmarks) do
+          local _, _, start_col, details = unpack(mark)
+          if details.url then
+            local end_col = details.end_col or (start_col + 1)
+            if click_col >= start_col and click_col < end_col then
+              vim.notify("Opening: " .. details.url, vim.log.levels.INFO)
+              vim.ui.open(details.url)
+              return
+            end
           end
         end
       end
@@ -166,6 +213,12 @@ PrDisplay.show_pr_info = function(pr)
   apply_content_to_buffer(buf, ns, content, pr.url)
   local win = open_float_window(buf, content)
   setup_float_keymaps(buf, ns, win, content)
+end
+
+-- Exported for testing
+PrDisplay._supports_osc8 = supports_osc8
+PrDisplay._reset_osc8_cache = function()
+  _osc8_supported = nil
 end
 
 return PrDisplay

--- a/tests/lualine_spec.lua
+++ b/tests/lualine_spec.lua
@@ -109,6 +109,75 @@ describe("Lualine module", function()
   end)
 end)
 
+describe("supports_osc8", function()
+  local pr_display
+  local saved_env
+
+  before_each(function()
+    package.loaded["ghsigns.pr_display"] = nil
+    package.loaded["ghsigns.content_builder"] = nil
+    pr_display = require "ghsigns.pr_display"
+
+    saved_env = {
+      TERM_PROGRAM = vim.env.TERM_PROGRAM,
+      VTE_VERSION = vim.env.VTE_VERSION,
+      WT_SESSION = vim.env.WT_SESSION,
+    }
+    vim.env.TERM_PROGRAM = nil
+    vim.env.VTE_VERSION = nil
+    vim.env.WT_SESSION = nil
+    pr_display._reset_osc8_cache()
+  end)
+
+  after_each(function()
+    vim.env.TERM_PROGRAM = saved_env.TERM_PROGRAM
+    vim.env.VTE_VERSION = saved_env.VTE_VERSION
+    vim.env.WT_SESSION = saved_env.WT_SESSION
+    pr_display._reset_osc8_cache()
+
+    package.loaded["ghsigns.pr_display"] = nil
+    package.loaded["ghsigns.content_builder"] = nil
+  end)
+
+  it("should return true for known OSC 8 terminals", function()
+    local terminals = { "iTerm.app", "WezTerm", "kitty", "foot", "contour", "rio", "alacritty", "ghostty" }
+    for _, term in ipairs(terminals) do
+      vim.env.TERM_PROGRAM = term
+      pr_display._reset_osc8_cache()
+      assert.is_true(pr_display._supports_osc8(), "Expected true for " .. term)
+    end
+  end)
+
+  it("should return true for VTE-based terminals", function()
+    vim.env.VTE_VERSION = "7200"
+    assert.is_true(pr_display._supports_osc8())
+  end)
+
+  it("should return true for Windows Terminal", function()
+    vim.env.WT_SESSION = "some-session-id"
+    assert.is_true(pr_display._supports_osc8())
+  end)
+
+  it("should return false for unknown terminals", function()
+    vim.env.TERM_PROGRAM = "unknown_terminal"
+    assert.is_false(pr_display._supports_osc8())
+  end)
+
+  it("should return false when no terminal env vars are set", function()
+    assert.is_false(pr_display._supports_osc8())
+  end)
+
+  it("should cache the result", function()
+    vim.env.TERM_PROGRAM = "WezTerm"
+    assert.is_true(pr_display._supports_osc8())
+
+    -- Change env after caching
+    vim.env.TERM_PROGRAM = nil
+    -- Should still return cached result
+    assert.is_true(pr_display._supports_osc8())
+  end)
+end)
+
 describe("PrDisplay module", function()
   local pr_display
 


### PR DESCRIPTION
## Summary
- OSC 8 対応ターミナル検出関数 `supports_osc8()` を追加（`TERM_PROGRAM` ホワイトリスト、`VTE_VERSION`、`WT_SESSION` で判定、結果はキャッシュ）
- OSC 8 対応ターミナルでは `<LeftRelease>` のリンク処理をスキップし、ターミナルネイティブのリンク処理に委ねる
- 非対応ターミナルでは従来通り `vim.ui.open` でリンクを開く

## Test plan
- [x] `supports_osc8` のユニットテスト追加（ホワイトリスト、VTE、WT、未知ターミナル、キャッシュ）
- [x] 既存テスト全 89 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)