### PR TITLE
chore: prepare for v1.0.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          # Extract the section for this version from CHANGELOG.md
+          awk '/^## \['"${{ steps.version.outputs.version }}"'\]/{found=1; next} /^## \[/{if(found) exit} found' CHANGELOG.md > release_notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release_notes.md
+          generate_release_notes: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [1.0.0] - 2026-02-22
+
+### Added
+
+- Core plugin that integrates gitsigns.nvim with GitHub CLI
+- Automatic PR information fetching for the current branch via `gh pr view`
+- Automatic diff base change to the PR's base branch using gitsigns' `change_base`
+- PR information caching by repository root and branch name
+- Asynchronous PR fetching to avoid blocking the editor
+- Lualine statusline component displaying branch name, base branch, and PR number
+- Interactive mouse click handling on the Lualine component:
+  - Single-click: Show detailed PR information in a floating window
+  - Double-click: Open the PR in the browser
+- Rich floating window for PR information display:
+  - PR title, draft status, author, state, review decision, mergeable status
+  - Branch information, labels, dates (created, updated, merged)
+  - Line changes (+/-), file count, and commit count
+  - Markdown-rendered PR description with syntax highlighting
+  - Clickable links (`[text](url)` format and `#123` issue/PR references)
+  - Close button, keyboard shortcuts (q/Esc/Enter), and click-outside-to-close
+- Markdown rendering engine supporting:
+  - Headings (h1-h3)
+  - Bold, strikethrough, inline code
+  - Links and issue/PR references
+  - Ordered and unordered lists
+  - Code blocks with language labels
+  - Blockquotes (including nested)
+  - HTML comment/tag stripping
+  - Long line wrapping with highlight preservation
+- OSC 8 terminal detection to prevent duplicate link opening behavior
+  - Supports iTerm2, WezTerm, kitty, foot, contour, rio, alacritty, ghostty
+  - Supports VTE-based terminals (GNOME Terminal, etc.) and Windows Terminal
+- Customizable colors for the Lualine component (icon, head, arrow, base)
+- Comprehensive test suite (89 tests) covering markdown rendering, PR content
+  rendering, lualine component, and OSC 8 detection
+- CI pipeline with GitHub Actions
+
+[1.0.0]: https://github.com/delphinus/ghsigns.nvim/releases/tag/v1.0.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 delphinus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 
 A Neovim plugin that integrates [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim) with GitHub CLI to automatically display Pull Request information in your statusline and show diffs against the PR's base branch.
 
-> [!WARNING]
-> This plugin is under active development. The API, configuration options, and setup methods may change frequently. Breaking changes may occur without prior notice. Please check the documentation regularly for updates.
-
 ## Features
 
 - Automatically fetches PR information for the current branch using GitHub CLI
@@ -177,9 +174,6 @@ MIT
 # 日本語
 
 [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim) と GitHub CLI を統合し、ステータスラインに Pull Request 情報を自動表示し、PR のベースブランチとの差分を表示する Neovim プラグインです。
-
-> [!WARNING]
-> このプラグインは活発に開発中です。API、設定オプション、セットアップ方法は頻繁に変更される可能性があります。予告なく破壊的変更が入ることがあります。定期的にドキュメントを確認してください。
 
 ## 機能
 


### PR DESCRIPTION
## Summary
- MIT LICENSE ファイルを追加
- CHANGELOG.md を追加（1.0.0 の全機能を記載）
- リリース用 GitHub Actions ワークフローを追加（`v*` タグ push 時に CHANGELOG から該当バージョンのセクションを抽出して GitHub Release を自動作成）
- README から「開発中」の WARNING を削除

## Test plan
- [x] 既存テスト全 89 件パス
- [ ] マージ後に `v1.0.0` タグを push し、release ワークフローが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)