### PR TITLE
fix: handle CJK line wrapping in floating window

### DIFF
--- a/lua/ghsigns/content_builder.lua
+++ b/lua/ghsigns/content_builder.lua
@@ -212,7 +212,55 @@ function ContentBuilder:build_header(p)
   return title_line, title_text
 end
 
---- Wrap text into lines at word boundaries, tracking original positions
+--- Split text into segments for wrapping, handling CJK/fullwidth characters individually.
+--- Each CJK/fullwidth character becomes its own segment so it can be wrapped independently.
+---@param text string
+---@return {text: string, byte_pos: integer, has_leading_space: boolean}[]
+local function split_segments(text)
+  local segments = {}
+  local current_word = ""
+  local current_word_start = 0
+  local has_leading_space = false
+  local byte_pos = 0
+
+  for char in text:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
+    if char:match "%s" then
+      -- Flush accumulated ASCII word
+      if current_word ~= "" then
+        table.insert(segments, { text = current_word, byte_pos = current_word_start, has_leading_space = has_leading_space })
+        current_word = ""
+        has_leading_space = false
+      end
+      has_leading_space = true
+    elseif vim.fn.strdisplaywidth(char) >= 2 then
+      -- CJK/fullwidth character: flush word first, then emit as individual segment
+      if current_word ~= "" then
+        table.insert(segments, { text = current_word, byte_pos = current_word_start, has_leading_space = has_leading_space })
+        current_word = ""
+        has_leading_space = false
+      end
+      table.insert(segments, { text = char, byte_pos = byte_pos, has_leading_space = has_leading_space })
+      has_leading_space = false
+    else
+      -- ASCII/narrow character: accumulate into word
+      if current_word == "" then
+        current_word_start = byte_pos
+      end
+      current_word = current_word .. char
+    end
+    byte_pos = byte_pos + #char
+  end
+
+  -- Flush remaining word
+  if current_word ~= "" then
+    table.insert(segments, { text = current_word, byte_pos = current_word_start, has_leading_space = has_leading_space })
+  end
+
+  return segments
+end
+
+--- Wrap text into lines at word boundaries, tracking original positions.
+--- Uses segment-based splitting to handle CJK/fullwidth characters correctly.
 ---@param text string The text to wrap
 ---@param max_width integer Maximum display width per line
 ---@return string[] wrapped_lines
@@ -223,35 +271,30 @@ local function wrap_words(text, max_width)
   local current = ""
   local current_width = 0
   local current_start = 0
-  local char_pos = 0
 
-  local words = {}
-  local word_positions = {}
-  for word in text:gmatch "%S+" do
-    local word_start = text:find(word, char_pos + 1, true)
-    table.insert(words, word)
-    table.insert(word_positions, word_start - 1)
-    char_pos = word_start + #word - 1
-  end
+  for _, seg in ipairs(split_segments(text)) do
+    local seg_width = vim.fn.strdisplaywidth(seg.text)
+    local space_width = (seg.has_leading_space and current ~= "") and 1 or 0
 
-  for i, word in ipairs(words) do
-    local word_width = vim.fn.strdisplaywidth(word)
-    local space_width = current == "" and 0 or 1
-
-    if current_width + space_width + word_width > max_width and current ~= "" then
+    if current_width + space_width + seg_width > max_width and current ~= "" then
       table.insert(wrapped_lines, current)
       table.insert(line_starts, current_start)
-      current = word
-      current_start = word_positions[i]
-      current_width = word_width
+      current = seg.text
+      current_start = seg.byte_pos
+      current_width = seg_width
     else
       if current ~= "" then
-        current = current .. " " .. word
-        current_width = current_width + 1 + word_width
+        if space_width > 0 then
+          current = current .. " " .. seg.text
+          current_width = current_width + 1 + seg_width
+        else
+          current = current .. seg.text
+          current_width = current_width + seg_width
+        end
       else
-        current = word
-        current_start = word_positions[i]
-        current_width = word_width
+        current = seg.text
+        current_start = seg.byte_pos
+        current_width = seg_width
       end
     end
   end
@@ -439,7 +482,8 @@ function ContentBuilder:add_markdown_line(text, indent, max_width, repo_base_url
   end
 end
 
---- Wrap long lines for code blocks
+--- Wrap long lines for code blocks.
+--- Uses segment-based splitting to handle CJK/fullwidth characters correctly.
 ---@param text string
 ---@param max_width integer
 ---@param indent string
@@ -449,21 +493,26 @@ local function wrap_line(text, max_width, indent)
   local current = ""
   local current_width = 0
 
-  for word in text:gmatch "%S+" do
-    local word_width = vim.fn.strdisplaywidth(word)
-    local space_width = current == "" and 0 or 1
+  for _, seg in ipairs(split_segments(text)) do
+    local seg_width = vim.fn.strdisplaywidth(seg.text)
+    local space_width = (seg.has_leading_space and current ~= "") and 1 or 0
 
-    if current_width + space_width + word_width > max_width and current ~= "" then
+    if current_width + space_width + seg_width > max_width and current ~= "" then
       table.insert(lines_out, indent .. current)
-      current = word
-      current_width = word_width
+      current = seg.text
+      current_width = seg_width
     else
       if current ~= "" then
-        current = current .. " " .. word
-        current_width = current_width + 1 + word_width
+        if space_width > 0 then
+          current = current .. " " .. seg.text
+          current_width = current_width + 1 + seg_width
+        else
+          current = current .. seg.text
+          current_width = current_width + seg_width
+        end
       else
-        current = word
-        current_width = word_width
+        current = seg.text
+        current_width = seg_width
       end
     end
   end

--- a/tests/rendering_spec.lua
+++ b/tests/rendering_spec.lua
@@ -500,6 +500,74 @@ describe("PR content rendering", function()
   end)
 
   ---------------------------------------------------------------------------
+  -- Group 3b: CJK line wrapping
+  ---------------------------------------------------------------------------
+  describe("CJK line wrapping", function()
+    it("should wrap pure CJK text at character boundaries", function()
+      -- 42 CJK chars = 84 display columns (each char is 2 cols wide)
+      -- max_width=80 means first 40 chars (80 cols) fit, then remaining 2 chars
+      local cjk = string.rep("あ", 42)
+      local c = build_with_body(cjk)
+      eq("  " .. string.rep("あ", 40), c.lines[7])
+      eq("  " .. string.rep("あ", 2), c.lines[8])
+    end)
+
+    it("should wrap mixed CJK and ASCII text", function()
+      -- "Hello " (6 cols) + 38 CJK chars (76 cols) = 82 cols, wraps at 80
+      -- "Hello " + 37 CJK (74 cols) = 80 cols on line 1, then 1 CJK on line 2
+      local mixed = "Hello " .. string.rep("あ", 38)
+      local c = build_with_body(mixed)
+      eq("  Hello " .. string.rep("あ", 37), c.lines[7])
+      eq("  " .. string.rep("あ", 1), c.lines[8])
+    end)
+
+    it("should preserve bold highlight positions in CJK text", function()
+      -- "**太字**のテスト" -> rendered as "太字のテスト" with bold on "太字"
+      -- Total: 12 display cols (fits in 80), so no wrapping needed
+      local c = build_with_body("**太字**のテスト")
+      eq("  太字のテスト", c.lines[7])
+      eq({
+        { col = 2, end_col = 8, hl = "Bold" },
+      }, hl_for_line(c, 6))
+    end)
+
+    it("should wrap CJK text inside blockquotes", function()
+      -- "│ " prefix takes 2 display cols; content area = 80 - 2 = 78 cols
+      -- 40 CJK chars = 80 display cols > 78 cols, so wraps
+      -- 39 CJK chars (78 cols) fit, then 1 char on next line
+      local bq = "> " .. string.rep("あ", 40)
+      local c = build_with_body(bq)
+      eq("  │ " .. string.rep("あ", 39), c.lines[7])
+      eq("  │ " .. string.rep("あ", 1), c.lines[8])
+      -- Blockquote prefix highlighted on both lines
+      eq({ col = 2, end_col = 6, hl = "FloatBorder" }, hl_for_line(c, 6)[1])
+      eq({ col = 2, end_col = 6, hl = "FloatBorder" }, hl_for_line(c, 7)[1])
+    end)
+
+    it("should preserve link highlight positions after CJK wrapping", function()
+      -- Long CJK text with a link that ends up on wrapped line
+      local text = string.rep("あ", 38) .. "[リンク](https://example.com)"
+      local c = build_with_body(text)
+      -- 38 "あ" = 76 cols. Link text "リンク" = 3 CJK chars, each wrapped individually.
+      -- "リ" (78 cols), "ン" (80 cols), "ク" -> 82 > 80, wraps.
+      -- Line 1: 38 "あ" + "リン" = 80 cols
+      -- Line 2: "ク" = 2 cols
+      -- The link "リンク" spans two lines -> 2 link_metadata entries
+      eq(2, #c.link_metadata)
+      eq("https://example.com", c.link_metadata[1].url)
+      eq("https://example.com", c.link_metadata[2].url)
+    end)
+
+    it("should wrap CJK text in code blocks", function()
+      -- Code block with CJK content exceeding 80 cols
+      local code = "```\n" .. string.rep("あ", 42) .. "\n```"
+      local c = build_with_body(code)
+      eq("  " .. string.rep("あ", 40), c.lines[8])
+      eq("  " .. string.rep("あ", 2), c.lines[9])
+    end)
+  end)
+
+  ---------------------------------------------------------------------------
   -- Group 4: Truncation
   ---------------------------------------------------------------------------
   describe("Truncation", function()


### PR DESCRIPTION
## Summary

- CJK テキスト（日本語・中国語・韓国語）を含む PR 説明を Floating Window で表示すると、スペース区切りの分割しかしていなかったためウィンドウが異常に横に広がっていた問題を修正
- CJK/全角文字を個別の折り返し単位として扱うセグメントベースの分割関数 `split_segments` を追加し、`wrap_words` と `wrap_line` の両方に適用
- 既存の ASCII テキスト折り返し動作には影響なし

## Test plan

- [x] 純 CJK テキストの 80 カラム折り返し
- [x] CJK + ASCII 混在テキストの折り返し
- [x] CJK テキストでの太字ハイライト位置保持
- [x] ブロッククォート内 CJK テキストの折り返し
- [x] CJK テキストでのリンクメタデータ位置保持
- [x] コードブロック内 CJK テキストの折り返し
- [x] 既存テスト全 89 件のリグレッションなし確認（全 95 件パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)