### PR TITLE
fix: improve floating window display

### DIFF
--- a/lua/ghsigns/content_builder.lua
+++ b/lua/ghsigns/content_builder.lua
@@ -157,7 +157,7 @@ function ContentBuilder:add_metadata_fields(p)
     self:add_labeled("Review", p.reviewDecision:gsub("_", " "), review_hl)
   end
 
-  if p.mergeable and p.mergeable ~= "" then
+  if p.state == "OPEN" and p.mergeable and p.mergeable ~= "" then
     local merge_hl = p.mergeable == "MERGEABLE" and "DiagnosticOk" or "DiagnosticError"
     self:add_labeled("Mergeable", p.mergeable, merge_hl)
   end
@@ -196,11 +196,11 @@ function ContentBuilder:build_header(p)
   local title_line, title_text = self:add_title_line(p)
 
   if p.baseRefName and p.headRefName then
-    local branch_info = string.format("%s ← %s", p.baseRefName, p.headRefName)
+    local branch_info = string.format("%s → %s", p.headRefName, p.baseRefName)
     self:add_line(branch_info, {
-      { col = 0, end_col = #p.baseRefName, hl = "String" },
-      { col = #p.baseRefName + 1, end_col = #p.baseRefName + 3, hl = "Operator" },
-      { col = #p.baseRefName + 4, end_col = -1, hl = "Identifier" },
+      { col = 0, end_col = #p.headRefName, hl = "Identifier" },
+      { col = #p.headRefName + 1, end_col = #p.headRefName + 3, hl = "Operator" },
+      { col = #p.headRefName + 4, end_col = -1, hl = "String" },
     })
   end
 
@@ -314,12 +314,16 @@ end
 ---@param indent string Indentation prefix
 ---@param quote_prefix string Blockquote prefix (may be empty)
 ---@param content_offset integer Byte offset of content within the original rendered text
+---@param list_prefix_len? integer Byte length of list marker prefix (0 if none)
 ---@return Ghsigns.Highlight.Group[][] per_line_highlights Array of highlight lists, one per wrapped line
-local function distribute_highlights(md_highlights, wrapped_lines, line_starts, indent, quote_prefix, content_offset)
+local function distribute_highlights(md_highlights, wrapped_lines, line_starts, indent, quote_prefix, content_offset, list_prefix_len)
+  list_prefix_len = list_prefix_len or 0
   local per_line = {}
   for idx, wline in ipairs(wrapped_lines) do
     local line_start_pos = line_starts[idx]
-    local line_prefix = quote_prefix ~= "" and (indent .. quote_prefix) or indent
+    local prefix_len = #quote_prefix + list_prefix_len
+    local line_prefix = (quote_prefix ~= "" and (indent .. quote_prefix) or indent)
+        .. (idx == 1 and "" or string.rep(" ", list_prefix_len))
     local line_hls = {}
 
     -- Add FloatBorder highlight for blockquote prefix on continuation lines
@@ -334,9 +338,18 @@ local function distribute_highlights(md_highlights, wrapped_lines, line_starts, 
     for _, hl in ipairs(md_highlights) do
       local hl_start = hl.col - content_offset
       local hl_end = hl.end_col - content_offset
-      local wline_end = line_start_pos + #wline
 
-      if hl.hl == "FloatBorder" and hl.col == 0 then
+      -- "Special" highlights (list markers) that end at or before the content start
+      -- should only appear on line 1 with their original positions
+      if hl.end_col <= content_offset and hl.hl == "Special" then
+        if idx == 1 then
+          table.insert(line_hls, {
+            col = #indent + #quote_prefix + hl.col,
+            end_col = #indent + #quote_prefix + hl.end_col,
+            hl = hl.hl,
+          })
+        end
+      elseif hl.hl == "FloatBorder" and hl.col == 0 then
         if idx == 1 then
           table.insert(line_hls, {
             col = #indent + hl.col,
@@ -344,14 +357,17 @@ local function distribute_highlights(md_highlights, wrapped_lines, line_starts, 
             hl = hl.hl,
           })
         end
-      elseif hl_end > line_start_pos and hl_start < wline_end then
-        local local_start = math.max(0, hl_start - line_start_pos)
-        local local_end = math.min(#wline, hl_end - line_start_pos)
-        table.insert(line_hls, {
-          col = local_start + #line_prefix,
-          end_col = local_end + #line_prefix,
-          hl = hl.hl,
-        })
+      else
+        local wline_end = line_start_pos + #wline
+        if hl_end > line_start_pos and hl_start < wline_end then
+          local local_start = math.max(0, hl_start - line_start_pos)
+          local local_end = math.min(#wline, hl_end - line_start_pos)
+          table.insert(line_hls, {
+            col = local_start + #line_prefix,
+            end_col = local_end + #line_prefix,
+            hl = hl.hl,
+          })
+        end
       end
     end
 
@@ -368,12 +384,15 @@ end
 ---@param quote_prefix string Blockquote prefix (may be empty)
 ---@param content_offset integer Byte offset of content within the original rendered text
 ---@param base_line integer Current line count in the builder (0-indexed, before adding wrapped lines)
+---@param list_prefix_len? integer Byte length of list marker prefix (0 if none)
 ---@return Ghsigns.LinkMetadata[] link_entries
-local function distribute_links(md_links, wrapped_lines, line_starts, indent, quote_prefix, content_offset, base_line)
+local function distribute_links(md_links, wrapped_lines, line_starts, indent, quote_prefix, content_offset, base_line, list_prefix_len)
+  list_prefix_len = list_prefix_len or 0
   local entries = {}
   for idx, wline in ipairs(wrapped_lines) do
     local line_start_pos = line_starts[idx]
-    local line_prefix = quote_prefix ~= "" and (indent .. quote_prefix) or indent
+    local line_prefix = (quote_prefix ~= "" and (indent .. quote_prefix) or indent)
+        .. (idx == 1 and "" or string.rep(" ", list_prefix_len))
 
     for _, link in ipairs(md_links) do
       local link_start = link.col_start - content_offset
@@ -403,7 +422,8 @@ end
 ---@param indent string
 ---@param max_width integer
 ---@param quote_prefix string
-function ContentBuilder:add_wrapped_markdown(rendered_text, md_highlights, md_links, indent, max_width, quote_prefix)
+---@param list_marker? string
+function ContentBuilder:add_wrapped_markdown(rendered_text, md_highlights, md_links, indent, max_width, quote_prefix, list_marker)
   local wrap_text = rendered_text
   local content_offset = 0
   if quote_prefix ~= "" then
@@ -411,20 +431,35 @@ function ContentBuilder:add_wrapped_markdown(rendered_text, md_highlights, md_li
     content_offset = #quote_prefix
   end
 
+  -- Strip list marker from wrap_text so wrapping is based on content only
+  local list_prefix_len = 0
+  if list_marker and list_marker ~= "" then
+    wrap_text = wrap_text:sub(#list_marker + 1)
+    content_offset = content_offset + #list_marker
+    list_prefix_len = #list_marker
+  end
+
   local content_max_width = max_width
   if quote_prefix ~= "" then
     content_max_width = max_width - vim.fn.strdisplaywidth(quote_prefix)
   end
+  if list_prefix_len > 0 then
+    content_max_width = content_max_width - vim.fn.strdisplaywidth(list_marker)
+  end
 
   local wrapped_lines, line_starts = wrap_words(wrap_text, content_max_width)
-  local per_line_hls = distribute_highlights(md_highlights, wrapped_lines, line_starts, indent, quote_prefix, content_offset)
+  local per_line_hls = distribute_highlights(md_highlights, wrapped_lines, line_starts, indent, quote_prefix, content_offset, list_prefix_len)
   local base_line = #self.lines
-  local link_entries = distribute_links(md_links, wrapped_lines, line_starts, indent, quote_prefix, content_offset, base_line)
+  local link_entries = distribute_links(md_links, wrapped_lines, line_starts, indent, quote_prefix, content_offset, base_line, list_prefix_len)
+
+  local list_prefix = list_marker or ""
+  local list_continuation = string.rep(" ", list_prefix_len)
 
   for idx, wline in ipairs(wrapped_lines) do
     local line_prefix = quote_prefix ~= "" and (indent .. quote_prefix) or indent
+    local lm = idx == 1 and list_prefix or list_continuation
     local line_hls = per_line_hls[idx]
-    self:add_line(line_prefix .. wline, #line_hls > 0 and line_hls or nil)
+    self:add_line(line_prefix .. lm .. wline, #line_hls > 0 and line_hls or nil)
   end
 
   for _, entry in ipairs(link_entries) do
@@ -468,7 +503,7 @@ end
 ---@param repo_base_url? string
 function ContentBuilder:add_markdown_line(text, indent, max_width, repo_base_url)
   local markdown = require "ghsigns.markdown"
-  local rendered_text, md_highlights, md_links, special_type = markdown.render(text, repo_base_url)
+  local rendered_text, md_highlights, md_links, special_type, list_marker = markdown.render(text, repo_base_url)
 
   local quote_prefix = ""
   if special_type == "blockquote" then
@@ -476,7 +511,7 @@ function ContentBuilder:add_markdown_line(text, indent, max_width, repo_base_url
   end
 
   if vim.fn.strdisplaywidth(rendered_text) > max_width then
-    self:add_wrapped_markdown(rendered_text, md_highlights, md_links, indent, max_width, quote_prefix)
+    self:add_wrapped_markdown(rendered_text, md_highlights, md_links, indent, max_width, quote_prefix, list_marker)
   else
     self:add_simple_markdown(rendered_text, md_highlights, md_links, indent)
   end
@@ -566,8 +601,29 @@ function ContentBuilder:build_body(p)
   local lines_shown = 0
   local max_lines = 15
   local max_width = 80
+  local prev_was_heading = false
+  local prev_was_blank = false
 
   for _, body_line in ipairs(cleaned_lines) do
+    local is_blank = body_line:match "^%s*$" ~= nil
+    local is_heading = (not in_code_block) and body_line:match "^#+%s+" ~= nil
+
+    -- Skip blank lines immediately after headings (outside code blocks)
+    if not in_code_block and is_blank and prev_was_heading then
+      prev_was_blank = true
+      goto continue
+    end
+
+    -- Auto-insert blank line before headings if not already preceded by one
+    if not in_code_block and is_heading and lines_shown > 0 and not prev_was_blank then
+      self:add_line "  "
+      lines_shown = lines_shown + 1
+      if lines_shown >= max_lines then
+        self:add_line("  ... (truncated)", { { col = 0, end_col = -1, hl = "Comment" } })
+        break
+      end
+    end
+
     local lines_before = #self.lines
 
     if body_line:match "^```" then
@@ -590,10 +646,15 @@ function ContentBuilder:build_body(p)
     local lines_added = #self.lines - lines_before
     lines_shown = lines_shown + lines_added
 
+    prev_was_heading = is_heading
+    prev_was_blank = is_blank
+
     if lines_shown >= max_lines then
       self:add_line("  ... (truncated)", { { col = 0, end_col = -1, hl = "Comment" } })
       break
     end
+
+    ::continue::
   end
 end
 

--- a/lua/ghsigns/lualine.lua
+++ b/lua/ghsigns/lualine.lua
@@ -29,7 +29,7 @@ Lualine.component = function()
       return table.concat({
         hl.icon .. "",
         hl.head .. git.head,
-        hl.arrow .. "←",
+        hl.arrow .. "→",
         ("%s%s #%d"):format(hl.base, revision, pr.number),
       }, " ")
     elseif git then

--- a/lua/ghsigns/markdown.lua
+++ b/lua/ghsigns/markdown.lua
@@ -247,10 +247,10 @@ Markdown.render = function(text, repo_base_url)
   -- Prepend blockquote prefix
   if is_blockquote then
     rendered_text = apply_blockquote_prefix(rendered_text, quote_prefix, highlights, links)
-    return rendered_text, highlights, links, "blockquote"
+    return rendered_text, highlights, links, "blockquote", list_marker
   end
 
-  return rendered_text, highlights, links, nil
+  return rendered_text, highlights, links, nil, list_marker
 end
 
 return Markdown

--- a/tests/rendering_spec.lua
+++ b/tests/rendering_spec.lua
@@ -79,11 +79,11 @@ describe("PR content rendering", function()
         baseRefName = "main",
         headRefName = "feature",
       }
-      eq("main ← feature", c.lines[2])
+      eq("feature → main", c.lines[2])
       eq({
-        { col = 0, end_col = 4, hl = "String" },
-        { col = 5, end_col = 7, hl = "Operator" },
-        { col = 8, end_col = -1, hl = "Identifier" },
+        { col = 0, end_col = 7, hl = "Identifier" },
+        { col = 8, end_col = 10, hl = "Operator" },
+        { col = 11, end_col = -1, hl = "String" },
       }, hl_for_line(c, 1))
     end)
 
@@ -280,7 +280,7 @@ describe("PR content rendering", function()
       }
       eq({
         "#99 [DRAFT] Draft Feature",
-        "main ← feature",
+        "feature → main",
         "",
         "Author: Author",
         "State: OPEN",
@@ -715,7 +715,7 @@ All 21 tests pass:
     it("should produce the expected lines", function()
       eq({
         "#4 feat: add strikethrough support and cache management",
-        "main ← demo/markdown-rendering-test",
+        "demo/markdown-rendering-test → main",
         "",
         "Author: JINNOUCHI Yasushi",
         "State: MERGED",
@@ -727,20 +727,20 @@ All 21 tests pass:
         "",
         "Description:",
         "  Summary",
-        "  ",
         "  This PR adds two enhancements to ghsigns.nvim:",
         "  ",
         "  - Add strikethrough rendering support to the markdown module",
         "  - Introduce cache utility methods (clear, invalidate, size) for better cache",
-        "  lifecycle management",
+        "    lifecycle management",
         "  ",
         "  Motivation",
-        "  ",
         "  │ Currently, the markdown renderer handles bold, inline code, links, and",
         "  │ headings — but it does not support strikethrough. GitHub-flavored Markdown",
         "  │ uses text extensively in PR descriptions, so this is a useful addition.",
         "  │ ",
         "  │ Additionally, the Cache class only supported get and set. There was no way to:",
+        "  │ 1. Clear the entire cache",
+        "  │ 2. Invalidate a specific entry",
         "  ... (truncated)",
         "",
         "✕ Click here to close (or press q/Esc/Enter)",
@@ -756,9 +756,9 @@ All 21 tests pass:
 
     it("should have correct branch highlights", function()
       eq({
-        { col = 0, end_col = 4, hl = "String" },
-        { col = 5, end_col = 7, hl = "Operator" },
-        { col = 8, end_col = -1, hl = "Identifier" },
+        { col = 0, end_col = 28, hl = "Identifier" },
+        { col = 29, end_col = 31, hl = "Operator" },
+        { col = 32, end_col = -1, hl = "String" },
       }, hl_for_line(pr4_content, 1))
     end)
 
@@ -790,12 +790,12 @@ All 21 tests pass:
     it("should have correct body highlights", function()
       -- "Summary" heading
       eq({ { col = 2, end_col = 9, hl = "Title" } }, hl_for_line(pr4_content, 12))
-      -- Bold "ghsigns.nvim" in line 14
-      eq({ { col = 35, end_col = 47, hl = "Bold" } }, hl_for_line(pr4_content, 14))
+      -- Bold "ghsigns.nvim" in line 13
+      eq({ { col = 35, end_col = 47, hl = "Bold" } }, hl_for_line(pr4_content, 13))
       -- "Motivation" heading
-      eq({ { col = 2, end_col = 12, hl = "Title" } }, hl_for_line(pr4_content, 20))
-      -- Blockquote on line 22 (first wrapped blockquote line)
-      local bq_hl = hl_for_line(pr4_content, 22)
+      eq({ { col = 2, end_col = 12, hl = "Title" } }, hl_for_line(pr4_content, 19))
+      -- Blockquote on line 20 (first wrapped blockquote line)
+      local bq_hl = hl_for_line(pr4_content, 20)
       assert.is_not_nil(bq_hl)
       eq({ col = 2, end_col = 6, hl = "FloatBorder" }, bq_hl[1])
     end)
@@ -803,7 +803,7 @@ All 21 tests pass:
     it("should have link_metadata for the example.com link", function()
       eq(1, #pr4_content.link_metadata)
       eq("https://example.com", pr4_content.link_metadata[1].url)
-      eq(22, pr4_content.link_metadata[1].line)
+      eq(20, pr4_content.link_metadata[1].line)
     end)
 
     it("should have correct meta values", function()
@@ -865,6 +865,119 @@ All 21 tests pass:
       assert.is_not_nil(close_hl)
       eq({ col = 0, end_col = 1, hl = "ErrorMsg" }, close_hl[1])
       eq({ col = 2, end_col = 46, hl = "Comment" }, close_hl[2])
+    end)
+  end)
+
+  ---------------------------------------------------------------------------
+  -- Group 7: Mergeable visibility
+  ---------------------------------------------------------------------------
+  describe("Mergeable visibility", function()
+    it("should not show Mergeable for MERGED PRs", function()
+      local c = pr_display.build_pr_content {
+        number = 1,
+        title = "T",
+        state = "MERGED",
+        mergeable = "UNKNOWN",
+      }
+      for _, l in ipairs(c.lines) do
+        assert.is_nil(l:match "^Mergeable:")
+      end
+    end)
+
+    it("should not show Mergeable for CLOSED PRs", function()
+      local c = pr_display.build_pr_content {
+        number = 1,
+        title = "T",
+        state = "CLOSED",
+        mergeable = "CONFLICTING",
+      }
+      for _, l in ipairs(c.lines) do
+        assert.is_nil(l:match "^Mergeable:")
+      end
+    end)
+
+    it("should show Mergeable for OPEN PRs", function()
+      local c = pr_display.build_pr_content {
+        number = 1,
+        title = "T",
+        state = "OPEN",
+        mergeable = "MERGEABLE",
+      }
+      local found = false
+      for _, l in ipairs(c.lines) do
+        if l:match "^Mergeable:" then
+          found = true
+          break
+        end
+      end
+      assert.is_true(found)
+    end)
+  end)
+
+  ---------------------------------------------------------------------------
+  -- Group 8: List wrapping continuation indent
+  ---------------------------------------------------------------------------
+  describe("List wrapping continuation indent", function()
+    it("should indent continuation lines for dash list items", function()
+      local long_item = "- This is a very long list item that should be wrapped because it exceeds the maximum width of eighty characters in the display"
+      local c = build_with_body(long_item)
+      eq("  - This is a very long list item that should be wrapped because it exceeds the", c.lines[7])
+      eq("    maximum width of eighty characters in the display", c.lines[8])
+    end)
+
+    it("should indent continuation lines for numbered list items", function()
+      local long_item = "1. This is a very long numbered list item that should be wrapped because it exceeds the maximum width of eighty characters"
+      local c = build_with_body(long_item)
+      eq("  1. This is a very long numbered list item that should be wrapped because it", c.lines[7])
+      eq("     exceeds the maximum width of eighty characters", c.lines[8])
+    end)
+
+    it("should show Special highlight only on the first line of wrapped list", function()
+      local long_item = "- This is a very long list item that should be wrapped because it exceeds the maximum width of eighty characters in the display"
+      local c = build_with_body(long_item)
+      -- First line should have Special highlight for the marker
+      local line1_hl = hl_for_line(c, 6)
+      assert.is_not_nil(line1_hl)
+      local found_special = false
+      for _, g in ipairs(line1_hl) do
+        if g.hl == "Special" then
+          found_special = true
+          break
+        end
+      end
+      assert.is_true(found_special)
+      -- Second line should NOT have Special highlight
+      local line2_hl = hl_for_line(c, 7)
+      if line2_hl then
+        for _, g in ipairs(line2_hl) do
+          assert.is_not.equal("Special", g.hl)
+        end
+      end
+    end)
+  end)
+
+  ---------------------------------------------------------------------------
+  -- Group 9: Heading blank line control
+  ---------------------------------------------------------------------------
+  describe("Heading blank line control", function()
+    it("should skip blank lines after headings", function()
+      local c = build_with_body "## Title\n\nContent"
+      eq("  Title", c.lines[7])
+      eq("  Content", c.lines[8])
+    end)
+
+    it("should insert blank line before headings when not preceded by one", function()
+      local c = build_with_body "Paragraph\n## Title"
+      eq("  Paragraph", c.lines[7])
+      eq("  ", c.lines[8])
+      eq("  Title", c.lines[9])
+    end)
+
+    it("should not insert extra blank line before headings when already preceded by one", function()
+      local c = build_with_body "Paragraph\n\n## Title"
+      eq("  Paragraph", c.lines[7])
+      eq("  ", c.lines[8])
+      eq("  Title", c.lines[9])
     end)
   end)
 end)


### PR DESCRIPTION
## Summary

- ブランチ表示順を `head → base` に統一（lualine / floating window 両方）
- MERGED/CLOSED 状態の PR で Mergeable フィールドを非表示に
- 箇条書きの折り返し時、継続行のインデントをマーカー幅に揃える
- ヘディング後の空行をスキップし、ヘディング前に空行がなければ自動挿入

## Test plan

- [x] `make test` — 全60テスト通過（既存51 + 新規9）
- [ ] Floating window でブランチ順が `head → base` になっていること
- [ ] MERGED PR で Mergeable 行が表示されないこと
- [ ] 長いリストアイテムの継続行がインデントされること
- [ ] ヘディング前後の空行が適切に制御されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)