### PR TITLE
feat: add treesitter syntax highlighting for code blocks

### DIFF
--- a/lua/ghsigns/content_builder.lua
+++ b/lua/ghsigns/content_builder.lua
@@ -16,10 +16,16 @@
 ---@field col_end integer 0-indexed end column
 ---@field url string
 
+---@class Ghsigns.CodeBlock
+---@field language string
+---@field start_line integer 0-indexed, first code line
+---@field end_line integer   0-indexed, last code line
+
 ---@class Ghsigns.PrContent
 ---@field lines string[]
 ---@field highlights Ghsigns.LineHighlight[]
 ---@field link_metadata Ghsigns.LinkMetadata[]
+---@field code_blocks Ghsigns.CodeBlock[]
 ---@field title_line integer
 ---@field title_text string
 ---@field close_line_idx integer
@@ -28,6 +34,7 @@
 ---@field lines string[]
 ---@field highlights Ghsigns.LineHighlight[]
 ---@field link_metadata Ghsigns.LinkMetadata[]
+---@field code_blocks Ghsigns.CodeBlock[]
 local ContentBuilder = {}
 
 ---@return Ghsigns.ContentBuilder
@@ -36,6 +43,7 @@ function ContentBuilder.new()
     lines = {},
     highlights = {},
     link_metadata = {},
+    code_blocks = {},
   }, { __index = ContentBuilder })
 end
 
@@ -65,6 +73,7 @@ function ContentBuilder:result()
     lines = self.lines,
     highlights = self.highlights,
     link_metadata = self.link_metadata,
+    code_blocks = self.code_blocks,
   }
 end
 
@@ -598,6 +607,8 @@ function ContentBuilder:build_body(p)
 
   local cleaned_lines = normalize_body(p.body)
   local in_code_block = false
+  local code_block_lang = nil
+  local code_block_start = nil
   local lines_shown = 0
   local max_lines = 15
   local max_width = 80
@@ -627,8 +638,22 @@ function ContentBuilder:build_body(p)
     local lines_before = #self.lines
 
     if body_line:match "^```" then
-      in_code_block = not in_code_block
-      self:add_line("  " .. body_line, { { col = 0, end_col = -1, hl = "Comment" } })
+      if not in_code_block then
+        in_code_block = true
+        code_block_lang = body_line:match "^```(%S+)" or nil
+        code_block_start = #self.lines -- 0-indexed position of next code line
+      else
+        if code_block_lang and code_block_start < #self.lines then
+          table.insert(self.code_blocks, {
+            language = code_block_lang,
+            start_line = code_block_start,
+            end_line = #self.lines - 1,
+          })
+        end
+        in_code_block = false
+        code_block_lang = nil
+      end
+      -- Don't call add_line: fence lines are hidden and don't count toward lines_shown
     elseif in_code_block then
       local display_width = vim.fn.strdisplaywidth(body_line)
       if display_width > max_width then

--- a/lua/ghsigns/pr_display.lua
+++ b/lua/ghsigns/pr_display.lua
@@ -66,6 +66,43 @@ PrDisplay.build_pr_content = function(pr)
   return result
 end
 
+--- Apply treesitter syntax highlighting to code blocks
+---@param buf integer
+---@param ns integer
+---@param content Ghsigns.PrContent
+local function apply_treesitter_highlights(buf, ns, content)
+  for _, block in ipairs(content.code_blocks or {}) do
+    local code_lines = {}
+    for i = block.start_line, block.end_line do
+      local line = content.lines[i + 1] or ""
+      table.insert(code_lines, line:sub(3)) -- remove "  " indent
+    end
+    local code_text = table.concat(code_lines, "\n")
+
+    local ok, parser = pcall(vim.treesitter.get_string_parser, code_text, block.language)
+    if not ok or not parser then goto continue end
+
+    local trees = parser:parse()
+    if not trees or #trees == 0 then goto continue end
+
+    local query = vim.treesitter.query.get(block.language, "highlights")
+    if not query then goto continue end
+
+    for id, node in query:iter_captures(trees[1]:root(), code_text) do
+      local name = query.captures[id]
+      local sr, sc, er, ec = node:range()
+      pcall(vim.api.nvim_buf_set_extmark, buf, ns, block.start_line + sr, sc + 2, {
+        end_row = block.start_line + er,
+        end_col = ec + 2,
+        hl_group = "@" .. name .. "." .. block.language,
+        priority = 110,
+      })
+    end
+
+    ::continue::
+  end
+end
+
 --- Apply highlights, link extmarks, and title extmark to a buffer
 ---@param buf integer
 ---@param ns integer
@@ -104,6 +141,8 @@ local function apply_content_to_buffer(buf, ns, content, pr_url)
       url = pr_url,
     })
   end
+
+  apply_treesitter_highlights(buf, ns, content)
 end
 
 --- Calculate window size and position, open the floating window

--- a/tests/rendering_spec.lua
+++ b/tests/rendering_spec.lua
@@ -369,17 +369,29 @@ describe("PR content rendering", function()
       }, hl_for_line(c, 6))
     end)
 
-    it("should render code blocks with Comment/String highlights", function()
+    it("should render code blocks with fence lines hidden and String highlight", function()
       local c = build_with_body "```lua\nlocal x = 1\n```"
-      eq("  ```lua", c.lines[7])
-      eq("  local x = 1", c.lines[8])
-      eq("  ```", c.lines[9])
-      -- Code block delimiters get Comment highlight
-      eq({ { col = 0, end_col = -1, hl = "Comment" } }, hl_for_line(c, 6))
-      -- Code block content gets String highlight
-      eq({ { col = 0, end_col = -1, hl = "String" } }, hl_for_line(c, 7))
-      -- Closing delimiter gets Comment highlight
-      eq({ { col = 0, end_col = -1, hl = "Comment" } }, hl_for_line(c, 8))
+      eq("  local x = 1", c.lines[7])
+      -- Fence lines are hidden, code content gets String highlight
+      eq({ { col = 0, end_col = -1, hl = "String" } }, hl_for_line(c, 6))
+    end)
+
+    it("should record code_blocks metadata for language-tagged code blocks", function()
+      local c = build_with_body "```lua\nlocal x = 1\nlocal y = 2\n```"
+      eq(1, #c.code_blocks)
+      eq("lua", c.code_blocks[1].language)
+      eq(6, c.code_blocks[1].start_line)
+      eq(7, c.code_blocks[1].end_line)
+    end)
+
+    it("should not record code_blocks for language-untagged code blocks", function()
+      local c = build_with_body "```\nsome code\n```"
+      eq(0, #c.code_blocks)
+    end)
+
+    it("should not record code_blocks for empty code blocks", function()
+      local c = build_with_body "```lua\n```"
+      eq(0, #c.code_blocks)
     end)
 
     it("should render blockquote with FloatBorder highlight", function()
@@ -559,11 +571,11 @@ describe("PR content rendering", function()
     end)
 
     it("should wrap CJK text in code blocks", function()
-      -- Code block with CJK content exceeding 80 cols
+      -- Code block with CJK content exceeding 80 cols (fence lines hidden)
       local code = "```\n" .. string.rep("あ", 42) .. "\n```"
       local c = build_with_body(code)
-      eq("  " .. string.rep("あ", 40), c.lines[8])
-      eq("  " .. string.rep("あ", 2), c.lines[9])
+      eq("  " .. string.rep("あ", 40), c.lines[7])
+      eq("  " .. string.rep("あ", 2), c.lines[8])
     end)
   end)
 


### PR DESCRIPTION
## Summary

- Hide fence lines (` ``` ` / ` ```lang `) from floating window display, saving vertical space
- Apply treesitter-based syntax highlighting to language-tagged code blocks in PR descriptions
- Retain `String` fallback highlight for code blocks without language tags or unsupported languages

## Changes

### `content_builder.lua`
- Add `CodeBlock` type and `code_blocks` metadata collection
- Fence lines no longer call `add_line` — they are hidden and don't count toward `lines_shown`
- Language-tagged code blocks with content are recorded in `code_blocks` for treesitter processing

### `pr_display.lua`
- Add `apply_treesitter_highlights()` — parses each code block with `vim.treesitter.get_string_parser`, runs the `highlights` query, and applies extmarks with `@capture.language` highlight groups at priority 110
- All operations are wrapped in `pcall` for error resilience

### `tests/rendering_spec.lua`
- Update existing code block and CJK code block tests for hidden fence lines
- Add 3 new tests: `code_blocks` metadata for tagged/untagged/empty blocks

## Test plan

- [x] `make test` — all 107 tests pass
- [ ] Manual: open floating window on a PR with code blocks, verify syntax highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)