### PR TITLE
fix: reorder release workflow to create release before CHANGELOG push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,16 +36,17 @@ jobs:
         env:
           OUTPUT: CHANGELOG.md
 
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release_notes.md
+          generate_release_notes: false
+
       - name: Commit and push CHANGELOG.md
+        continue-on-error: true
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
           git commit -m "docs: update CHANGELOG.md for ${GITHUB_REF_NAME}" || true
           git push origin HEAD:main
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: release_notes.md
-          generate_release_notes: false


### PR DESCRIPTION
## Summary

- Move GitHub Release creation step before the CHANGELOG commit/push step in `release.yml`
- Add `continue-on-error: true` to the CHANGELOG push step so branch protection rules don't block the release

The v1.3.1 release failed because the direct push to `main` was rejected by branch protection, which also prevented the GitHub Release from being created.

## Test plan

- [ ] After merge, push v1.3.1 tag and verify the GitHub Release is created successfully
- [ ] Verify the CHANGELOG push step fails gracefully without blocking the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)