### PR TITLE
docs: add release procedure and verify CHANGELOG in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify CHANGELOG.md is up to date
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          if ! grep -q "^## \[${version}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md does not contain an entry for version ${version}."
+            echo "Run 'git-cliff --output CHANGELOG.md' and commit the result before tagging."
+            exit 1
+          fi
+
       - name: Generate release notes
         id: release_notes
         uses: orhun/git-cliff-action@v4
@@ -28,25 +37,8 @@ jobs:
         env:
           OUTPUT: release_notes.md
 
-      - name: Generate full changelog
-        uses: orhun/git-cliff-action@v4
-        with:
-          config: cliff.toml
-          args: --output CHANGELOG.md
-        env:
-          OUTPUT: CHANGELOG.md
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           body_path: release_notes.md
           generate_release_notes: false
-
-      - name: Commit and push CHANGELOG.md
-        continue-on-error: true
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git commit -m "docs: update CHANGELOG.md for ${GITHUB_REF_NAME}" || true
-          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -165,6 +165,28 @@ make test-lualine
   - Floating window creation and management
   - PR information display
 
+### Releasing
+
+1. Update CHANGELOG.md with git-cliff and commit:
+
+```bash
+git-cliff --output CHANGELOG.md
+git add CHANGELOG.md
+git commit -m "docs: update CHANGELOG.md for vX.Y.Z"
+```
+
+2. Merge the changes into `main` via a pull request.
+
+3. Create and push a version tag:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The release workflow will verify that CHANGELOG.md contains the version entry,
+generate release notes with git-cliff, and create a GitHub Release automatically.
+
 ## License
 
 MIT
@@ -335,6 +357,28 @@ make test-lualine
   - クリックハンドラー（シングル/ダブルクリック）
   - フローティングウィンドウの作成と管理
   - PR 情報の表示
+
+### リリース
+
+1. git-cliff で CHANGELOG.md を更新してコミット:
+
+```bash
+git-cliff --output CHANGELOG.md
+git add CHANGELOG.md
+git commit -m "docs: update CHANGELOG.md for vX.Y.Z"
+```
+
+2. Pull Request 経由で `main` にマージ。
+
+3. バージョンタグを作成して push:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+リリースワークフローが CHANGELOG.md にバージョンエントリがあることを検証し、
+git-cliff でリリースノートを生成して GitHub Release を自動作成します。
 
 ## ライセンス
 


### PR DESCRIPTION
## Summary

- Add CHANGELOG version verification step to `release.yml` — workflow fails early with a clear error if `git-cliff` was not run before tagging
- Remove the auto-commit/push step that was blocked by branch protection rules
- Document the release procedure in README (English and Japanese sections)

## Test plan

- [ ] Push a tag without updating CHANGELOG.md and verify the workflow fails with the expected error message
- [ ] Follow the documented release procedure and verify the workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)