### PR TITLE
docs: update CHANGELOG.md for v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.2] - 2026-02-23
+
+### Documentation
+
+- add release procedure and verify CHANGELOG in workflow
+
+## [1.3.1] - 2026-02-23
+
+### Changed
+
+- introduce git-cliff for automated CHANGELOG generation
+
+### Fixed
+
+- reorder release workflow to create release before CHANGELOG push
+
 ## [1.3.0] - 2026-02-22
 
 ### Documentation
@@ -96,6 +112,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - embed PR #4 body inline instead of reading from /tmp
 - prevent duplicate link opening in OSC 8 terminals
 
+[1.3.2]: https://github.com/delphinus/ghsigns.nvim/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/delphinus/ghsigns.nvim/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/delphinus/ghsigns.nvim/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/delphinus/ghsigns.nvim/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/delphinus/ghsigns.nvim/compare/v1.0.1...v1.1.0


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md with git-cliff for v1.3.2 release

## Test plan

- [ ] After merge, push v1.3.2 tag and verify the release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)