### PR TITLE
fix: collapse consecutive spaces in markdown to prevent highlight offset

### DIFF
--- a/lua/ghsigns/markdown.lua
+++ b/lua/ghsigns/markdown.lua
@@ -206,6 +206,9 @@ end
 ---@return string? special_type Special type like "heading" if applicable
 Markdown.render = function(text, repo_base_url)
   local rendered_text = text:gsub("\r", "")
+  -- Collapse multiple consecutive spaces (preserve leading whitespace)
+  local leading_ws = rendered_text:match "^(%s*)" or ""
+  rendered_text = leading_ws .. rendered_text:sub(#leading_ws + 1):gsub("  +", " ")
   local highlights = {}
   local links = {}
 

--- a/tests/markdown_spec.lua
+++ b/tests/markdown_spec.lua
@@ -93,6 +93,21 @@ describe("Markdown rendering", function()
       local text = markdown.render("Run `npm install` then `npm start`")
       eq("Run npm install then npm start", text)
     end)
+
+    it("should correctly highlight inline code after multiple consecutive spaces", function()
+      local text, highlights = markdown.render("one of  `edit`, `tabedit`")
+      -- Multiple spaces should be collapsed to one
+      eq("one of edit, tabedit", text)
+      local code_hls = {}
+      for _, hl in ipairs(highlights) do
+        if hl.hl == "String" then
+          table.insert(code_hls, hl)
+        end
+      end
+      eq(2, #code_hls)
+      eq("edit", text:sub(code_hls[1].col + 1, code_hls[1].end_col))
+      eq("tabedit", text:sub(code_hls[2].col + 1, code_hls[2].end_col))
+    end)
   end)
 
   describe("Issue references", function()


### PR DESCRIPTION
## Summary

- Fix inline code highlight being shifted when PR body text contains multiple consecutive spaces (e.g. `"one of  `edit`"`)
- `wrap_words` collapses multiple spaces to one, but highlight positions were based on the original text, causing the first character(s) of inline code to be unhighlighted
- Normalize consecutive spaces to a single space early in `Markdown.render`, preserving leading whitespace for list indentation

## Test plan

- [x] Added test case for inline code after consecutive spaces
- [x] All 108 existing tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)